### PR TITLE
add iCal support (allowing users to subscribe to meetings in their favorite calendar app)

### DIFF
--- a/src/ical.php
+++ b/src/ical.php
@@ -1,0 +1,175 @@
+<?php
+/*
+     iCAL-Extension for lobbycal2press
+	 json example full: https://lobbycal.greens-efa-service.eu/api/meetings/mep/
+	 json example detail: https://lobbycal.greens-efa-service.eu/api/meetings/mep/8
+	 provided by @RobertHarm, re-using work from webtermine.at
+*/
+//info: construct path to wp-load.php and initialize WordPress
+while(!is_file('wp-load.php')) {
+	if(is_dir('..' . DIRECTORY_SEPARATOR)) chdir('..' . DIRECTORY_SEPARATOR);
+	else die('Error: Could not construct path to wp-load.php');
+}
+include( 'wp-load.php' );
+
+/**HELPER FUNCTIONS**/
+/** Quotes iCalendar special characters. */
+function ec3_ical_quote($string) {
+	$s = preg_replace('/([\\,;])/','\\\\$1',$string);
+	$s = preg_replace('/\r?\n/','\\\\n',$s);
+	$s = preg_replace('/\r/',' ',$s);
+	return $s;
+}
+/** Folds an iCalendar content-line so that it does not exceed
+*  75 characters. Appends CRLF to the end of the line. */
+function ec3_ical_fold($string, $max = 75) {
+	$result = '';
+	$s = $string;
+	while(strlen($s)>$max)
+	{
+	  $len = $max;
+	  while( $len>($max-10) && substr($s,$len-1,1) == '\\' )
+		$len --;
+	  $result .= substr($s,0,$len) . "\r\n\t";
+	  $s = substr($s,$len);
+	}
+	$result .= $s;
+	//    return $result."\r\n";
+	return $result."\r\n";
+}
+/** Folds an iCalendar content-line and echos it to stdout */
+function ec3_ical_echo($string, $max = 75) {
+	echo utf8_encode(ec3_ical_fold($string, $max));
+}
+
+/*DATE TIME HELPER*/
+function ec3_tz_push($tz) {
+	$old_tz=date_default_timezone_get();
+	date_default_timezone_set($tz);
+	return $old_tz;
+}
+function ec3_tz_pop($tz) {
+	date_default_timezone_set($tz);
+}
+/** Converts a WordPress timestamp (string in local time) to Unix time. */
+function ec3_to_time($timestamp) {
+	//global $ec3;
+	// Parse $timestamp and extract the Unix time.
+	$old_tz=ec3_tz_push($ec3->tz);
+	$unix_time = strtotime($timestamp);
+	ec3_tz_pop($old_tz);
+	// Unix time is seconds since the epoch (in UTC).
+	return $unix_time;
+}
+/** Converts a WordPress timestamp (string in local time) to
+ *  string in formatted UTC. */
+function ec3_to_utc($timestamp,$fmt='%Y%m%dT%H%M00Z') {
+	$result = gmstrftime($fmt,ec3_to_time($timestamp));
+	return $result;
+}
+
+$options = get_option ( 'lobbycal2press_settings' );
+$api_url = $options['lobbycal2press_text_field_apiURL'];
+
+//info: override $api_url for testing purposes
+if (isset($_GET['full'])) {
+	$api_url = 'https://lobbycal.greens-efa-service.eu/api/meetings/';
+}
+
+$result = wp_remote_get($api_url, array( 'sslverify' => true, 'timeout' => 10 ) );
+
+if ( !is_wp_error($result) && isset($result['response']['code']) && ($result['response']['code'] == 200) ){
+	$json = json_decode($result['body']);
+	
+	//header('Content-type: application/json; charset=utf-8');
+	header('Content-Type: text/calendar; charset=' . get_option('blog_charset'));
+	header('Content-Disposition: inline; filename=' . $options['lobbycal2press_ical_filename']);
+	header('Expires: Wed, 11 Jan 1984 05:00:00 GMT');
+	header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+	header('Cache-Control: no-cache, must-revalidate, max-age=0');
+	header('Pragma: no-cache');
+	ec3_ical_echo('BEGIN:VCALENDAR').PHP_EOL;
+	ec3_ical_echo('VERSION:2.0').PHP_EOL;
+	$ical_calendar_name = ec3_ical_echo('X-WR-CALNAME:' . $options['lobbycal2press_ical_calendar_name']);
+	echo $ical_calendar_name; 
+	ec3_ical_echo("X-WR-TIMEZONE:Europe/Brussels").PHP_EOL;
+	$ical_calendar_description = ec3_ical_echo('X-WR-CALDESC:' . $options['lobbycal2press_ical_calendar_description']);
+	echo $ical_calendar_description; 
+	ec3_ical_echo("CALSCALE:GREGORIAN").PHP_EOL;
+
+	$first = true;
+	foreach($json as $detail) {
+		if ($first) $first = false;
+
+			ec3_ical_echo('BEGIN:VEVENT');			
+			ec3_ical_echo('UID:'.md5("$detail->id . $detail->userid")."@lobbycal2press");
+			$title_prefix = '';
+			if ($options['lobbycal2press_ical_title_prefix'] != NULL) {
+				$title_prefix .= $options['lobbycal2press_ical_title_prefix'];
+			} 
+			$the_title_ical = $title_prefix .  ' ' . str_replace("&#8211;","-",str_replace("&#8220;","\"",str_replace("&#8221;","\"",str_replace("&#038;","&",$detail->title))));
+			ec3_ical_echo('SUMMARY:'.utf8_decode(ec3_ical_quote($the_title_ical)));
+			
+			//info: static url for all meetings
+			if ($options['lobbycal2press_ical_static_url'] != NULL) {
+				$static_url_raw = $options['lobbycal2press_ical_static_url'];
+				$static_url = ec3_ical_echo("URL;VALUE=URI:$static_url_raw");
+				echo $static_url;
+			}
+			
+			//info: add infos about meeting partners
+			$description = 'Participants:\n' . $detail->userFirstName . ' ' . $detail->userLastName . ' and ';
+			$first_partner = true;
+			foreach($detail->partners as $partner) {
+				if ($first_partner) { $first_partner = false; } else { $description .= ', '.PHP_EOL; }
+				$description .= $partner->name;
+				if ($partner->transparencyRegisterID != NULL) {
+					$description .= ' (transparencyRegisterID: '. $partner->transparencyRegisterID;
+				} else {
+					$description .= ' (no transparencyRegisterID available)';
+				}
+			}
+			
+			//info: add tags
+			if ($detail->tags != NULL) {
+				$description .= '\n\nTags:\n';
+				$first_tag = true;
+				foreach($detail->tags as $tag) {
+					if ($first_tag) { $first_tag = false; } else { $description .= ', '; }
+					$description .= $tag->i18nKey;
+				}
+			} else {
+				$description .= '\n\nNo tags available for this meeting.';
+			}
+			
+			//info: add static content for all meetings
+			if ($options['lobbycal2press_ical_static_content'] != NULL) {
+				$description .= '\n\n---\n' . $options['lobbycal2press_ical_static_content'];
+			}
+						
+			ec3_ical_echo('DESCRIPTION:'.utf8_decode(ec3_ical_quote($description)));
+
+			//info: ec3_ical_echo('TRANSP:OPAQUE'); // for availability - removed by request from @mleyrer
+			//info: Convert timestamps to UTC
+			ec3_ical_echo('DTSTART;VALUE=DATE-TIME:'.ec3_to_utc($detail->startDate));
+			ec3_ical_echo('DTEND;VALUE=DATE-TIME:'.ec3_to_utc($detail->endDate));
+			
+			//info: fixed location for all meetings
+			if ($options['lobbycal2press_ical_fixed_location'] != NULL) {
+				$fixed_location = ec3_ical_echo('LOCATION:' . $options['lobbycal2press_ical_fixed_location']);
+				echo $fixed_location;
+			}
+
+			//info: fixed lat+lon values for all meetings
+			if ( ($options['lobbycal2press_ical_fixed_location_latitude'] != NULL) && ($options['lobbycal2press_ical_fixed_location_longitude'] != NULL) ) {
+				$geo = ec3_ical_echo('GEO:' . floatval($options['lobbycal2press_ical_fixed_location_latitude']) . ';' . floatval($options['lobbycal2press_ical_fixed_location_longitude']));
+				echo $geo;
+			}
+			 
+			ec3_ical_echo('END:VEVENT');
+	} 
+	ec3_ical_echo('END:VCALENDAR');
+
+} else if ( is_wp_error($result) ) {
+	echo "WP HTTP error: " . $result->get_error_message();
+}

--- a/src/lobbycal2press.php
+++ b/src/lobbycal2press.php
@@ -1,11 +1,11 @@
 <?php
 /*
  * Plugin Name: lobbycal2press for wordpress
- * Plugin URI: http://lobbycal.greens-efa-service.eu
+ * Plugin URI: http://lobbycal.transparency.eu
  * Description: Plugin to display meetings from lobbycal.greens-efa-service.eu. Based on http://datatables.net/dev/knockout/
  * Version: 1.1
  * Author: GREENS EFA EU
- * Author URI: http://lobbycal.greens-efa-service.eu
+ * Author URI: http://lobbycal.transparency.eu
  * License: GPL
  */
 function lobbycal2press_scripts() {
@@ -60,6 +60,9 @@ function lobbycal2press_scripts() {
 	        var lc2pShowTags  = '<?php echo $options['lobbycal2press_checkbox_field_tags']; ?>';
 
 	        var lc2pShowTagsTitle  = '<?php echo $options['lobbycal2press_checkbox_field_tagsTitle']; ?>';
+			var lc2pOrder = '<?php echo $options['lobbycal2press_radio_field_order']; ?>';
+	        lc2pOrder = (lc2pOrder === undefined) ? 'date asc' : lc2pOrder;
+	        lc2pOrder = (lc2pOrder === '') ? 'date asc' : lc2pOrder;
 	        var lc2pPerPage  = '<?php echo $options['lobbycal2press_text_field_perPage']; ?>';
 	        lc2pPerPage = (lc2pPerPage === undefined) ? 10 : lc2pPerPage;
 	        lc2pPerPage = (lc2pPerPage === '') ? 10 : lc2pPerPage;
@@ -98,6 +101,8 @@ function lobbycal2press_settings_init() {
 	add_settings_field ( 'lobbycal2press_checkbox_field_firstname', __ ( 'Display column for MEP first name?', 'lobbycal2press' ), 'lobbycal2press_checkbox_field_firstname_render', 'pluginPage', 'lobbycal2press_pluginPage_section' );
 	
 	add_settings_field ( 'lobbycal2press_checkbox_field_lastname', __ ( 'Display column for MEP last name?', 'lobbycal2press' ), 'lobbycal2press_checkbox_field_lastname_render', 'pluginPage', 'lobbycal2press_pluginPage_section' );
+
+	add_settings_field ( 'lobbycal2press_radio_field_order', __ ( 'What is the default order when loaded for the first time?', 'lobbycal2press' ), 'lobbycal2press_radio_field_order_render', 'pluginPage', 'lobbycal2press_pluginPage_section' );
 	
 	add_settings_field ( 'lobbycal2press_textarea_field_example', __ ( 'Use this code to place the calendar in a post or page', 'lobbycal2press' ), 'lobbycal2press_textarea_field_example_render', 'pluginPage', 'lobbycal2press_pluginPage_section' );
 	
@@ -369,11 +374,78 @@ function lobbycal2press_checkbox_field_tagsTitle_render() {
 	value='1'>
 <?php
 }
+function lobbycal2press_radio_field_order_render() {
+	$options = get_option ( 'lobbycal2press_settings' );
+	?>
+<input type='radio'
+	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
+	<?php checked( $options['lobbycal2press_radio_field_order'], 'startDate asc'); ?>
+	value='startDate asc'>
+Start date ascending
+</input>
+<br />
+<input type='radio'
+	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
+	<?php checked( $options['lobbycal2press_radio_field_order'],  'startDate desc'); ?>
+	value='startDate desc'>
+Start date descending
+</input>
+<br />
+<input type='radio'
+	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
+	<?php checked( $options['lobbycal2press_radio_field_order'], 'endDate asc'); ?>
+	value='endDate asc'>
+End date ascending
+</input>
+<br />
+<input type='radio'
+	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
+	<?php checked( $options['lobbycal2press_radio_field_order'],  'endDate desc'); ?>
+	value='endDate desc'>
+End date descending
+</input>
+<br />
+
+
+
+<input type='radio'
+	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
+	<?php checked( $options['lobbycal2press_radio_field_order'], 'userLastName asc'); ?>
+	value='userLastName asc'>
+Last name ascending
+</input>
+<br />
+<input type='radio'
+	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
+	<?php checked( $options['lobbycal2press_radio_field_order'],  'userLastName desc'); ?>
+	value='userLastName desc'>
+Last name descending
+</input>
+<br />
+
+
+
+
+<input type='radio'
+	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
+	<?php checked( $options['lobbycal2press_radio_field_order'], 'partners asc'); ?>
+	value='partners asc'>
+Partner ascending
+</input>
+<br />
+<input type='radio'
+	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
+	<?php checked( $options['lobbycal2press_radio_field_order'],  'partners desc'); ?>
+	value='partners desc'>
+Partner descending
+</input>
+<br />
+
+
+<?php
+}
 function lobbycal2press_settings_section_callback() {
 	echo __ ( 'The URL and at least one field are mandatory for the plugin to work. <br/> Make sure to use the https protocol here if your websites are accessed via https themselves.<br/> The default sorting of meetings is latest first.', 'lobbycal2press' );
-}
-function lobbycal2press_settings_section_ical_callback() {
-	echo __ ( 'Each calendar also automatically generates an iCal feed which can be used to automatically integrate the meetings into calendar programs like Outlook or Google Calendar for example. Some supported iCal metadata information is not available (yet?) from the API - anyway those info can be set globally below for all events. For tutorials on how to integrate an iCal feed with popular calendar clients, please have a look at <a href="https://www.webtermine.at/abo/abo-ical/" target="_blank">https://www.webtermine.at/abo/abo-ical/</a> (German)', 'lobbycal2press' );
 }
 function lobbycal2press_options_page() {
 	?>

--- a/src/lobbycal2press.php
+++ b/src/lobbycal2press.php
@@ -1,11 +1,11 @@
 <?php
 /*
  * Plugin Name: lobbycal2press for wordpress
- * Plugin URI: http://lobbycal.transparency.eu
- * Description: Plugin to display meetings from lobbycal.transparency.eu. Based on http://datatables.net/dev/knockout/
- * Version: 1.0
+ * Plugin URI: http://lobbycal.greens-efa-service.eu
+ * Description: Plugin to display meetings from lobbycal.greens-efa-service.eu. Based on http://datatables.net/dev/knockout/
+ * Version: 1.1
  * Author: GREENS EFA EU
- * Author URI: http://lobbycal.transparency.eu
+ * Author URI: http://lobbycal.greens-efa-service.eu
  * License: GPL
  */
 function lobbycal2press_scripts() {
@@ -60,10 +60,6 @@ function lobbycal2press_scripts() {
 	        var lc2pShowTags  = '<?php echo $options['lobbycal2press_checkbox_field_tags']; ?>';
 
 	        var lc2pShowTagsTitle  = '<?php echo $options['lobbycal2press_checkbox_field_tagsTitle']; ?>';
-	        
-	        var lc2pOrder = '<?php echo $options['lobbycal2press_radio_field_order']; ?>';
-	        lc2pOrder = (lc2pOrder === undefined) ? 'date asc' : lc2pOrder;
-	        lc2pOrder = (lc2pOrder === '') ? 'date asc' : lc2pOrder;
 	        var lc2pPerPage  = '<?php echo $options['lobbycal2press_text_field_perPage']; ?>';
 	        lc2pPerPage = (lc2pPerPage === undefined) ? 10 : lc2pPerPage;
 	        lc2pPerPage = (lc2pPerPage === '') ? 10 : lc2pPerPage;
@@ -103,10 +99,148 @@ function lobbycal2press_settings_init() {
 	
 	add_settings_field ( 'lobbycal2press_checkbox_field_lastname', __ ( 'Display column for MEP last name?', 'lobbycal2press' ), 'lobbycal2press_checkbox_field_lastname_render', 'pluginPage', 'lobbycal2press_pluginPage_section' );
 	
-	add_settings_field ( 'lobbycal2press_radio_field_order', __ ( 'What is the default order when loaded for the first time?', 'lobbycal2press' ), 'lobbycal2press_radio_field_order_render', 'pluginPage', 'lobbycal2press_pluginPage_section' );
-	
 	add_settings_field ( 'lobbycal2press_textarea_field_example', __ ( 'Use this code to place the calendar in a post or page', 'lobbycal2press' ), 'lobbycal2press_textarea_field_example_render', 'pluginPage', 'lobbycal2press_pluginPage_section' );
+	
+	/*ical*/
+	add_settings_section ( 'lobbycal2press_pluginPage_section_ical', __ ( 'iCal Settings for lobbycal2press plugin', 'lobbycal2press' ), 'lobbycal2press_settings_section_ical_callback', 'pluginPage' );
+
+	add_settings_field ( 'lobbycal2press_ical_calendar_name', __ ( 'calendar name', 'lobbycal2press' ), 'lobbycal2press_ical_calendar_name_render', 'pluginPage', 'lobbycal2press_pluginPage_section_ical' );
+	add_settings_field ( 'lobbycal2press_ical_calendar_description', __ ( 'calendar description', 'lobbycal2press' ), 'lobbycal2press_ical_calendar_description_render', 'pluginPage', 'lobbycal2press_pluginPage_section_ical' );
+	add_settings_field ( 'lobbycal2press_ical_title_prefix', __ ( 'title prefix for all meetings', 'lobbycal2press' ), 'lobbycal2press_ical_title_prefix_render', 'pluginPage', 'lobbycal2press_pluginPage_section_ical' );
+	add_settings_field ( 'lobbycal2press_ical_static_content', __ ( 'static content to be added at the end of each meeting description', 'lobbycal2press' ), 'lobbycal2press_ical_static_content_render', 'pluginPage', 'lobbycal2press_pluginPage_section_ical' );
+	add_settings_field ( 'lobbycal2press_ical_static_url', __ ( 'static url for all meetings', 'lobbycal2press' ), 'lobbycal2press_ical_static_url_render', 'pluginPage', 'lobbycal2press_pluginPage_section_ical' );
+	add_settings_field ( 'lobbycal2press_ical_filename', __ ( 'filename of iCal file', 'lobbycal2press' ), 'lobbycal2press_ical_filename_render', 'pluginPage', 'lobbycal2press_pluginPage_section_ical' );
+	add_settings_field ( 'lobbycal2press_ical_fixed_location', __ ( 'geolocation 1: use fixed location for all meetings (eg EU Parliament)', 'lobbycal2press' ), 'lobbycal2press_ical_fixed_location_render', 'pluginPage', 'lobbycal2press_pluginPage_section_ical' );
+	add_settings_field ( 'lobbycal2press_ical_fixed_location_lat', __ ( 'geolocation 2a: use fixed latitude value for all meetings (eg 50.838908)', 'lobbycal2press' ), 'lobbycal2press_ical_fixed_location_latitude_render', 'pluginPage', 'lobbycal2press_pluginPage_section_ical' );
+	add_settings_field ( 'lobbycal2press_ical_fixed_location_lon', __ ( 'geolocation 2b: use fixed longitude value for all meetings (eg 4.373942)', 'lobbycal2press' ), 'lobbycal2press_ical_fixed_location_longitude_render', 'pluginPage', 'lobbycal2press_pluginPage_section_ical' );
 }
+
+function lobbycal2press_ical_calendar_name_render() {
+	$options = get_option ( 'lobbycal2press_settings' );
+	if ($options['lobbycal2press_ical_calendar_name'] == NULL) {
+		$ical_calendar_name = 'LobbyCalendar for ';
+	} else {
+		$ical_calendar_name = $options['lobbycal2press_ical_calendar_name'];
+	}	
+	?>
+	<input type='text'
+	name='lobbycal2press_settings[lobbycal2press_ical_calendar_name]'
+	size="60"
+	value='<?php echo $ical_calendar_name;  ?>'>
+<?php }
+
+function lobbycal2press_ical_calendar_description_render() {
+	$options = get_option ( 'lobbycal2press_settings' );
+	if ($options['lobbycal2press_ical_calendar_description'] == NULL) {
+		$ical_calendar_description = 'This calendar shows information about meetings held with lobbyists and interest representatives such as civil society organisations.';
+	} else {
+		$ical_calendar_description = $options['lobbycal2press_ical_calendar_description'];
+	}	
+	?>
+	<input type='text'
+	name='lobbycal2press_settings[lobbycal2press_ical_calendar_description]'
+	size="60"
+	value='<?php echo $ical_calendar_description;  ?>'>
+<?php }
+
+function lobbycal2press_ical_filename_render() {
+	$options = get_option ( 'lobbycal2press_settings' );
+	if ($options['lobbycal2press_ical_filename'] == NULL) {
+		$ical_filename = 'lobbycal2press.ics';
+	} else {
+		$ical_filename = $options['lobbycal2press_ical_filename'];
+	}	
+	?>
+	<input type='text'
+	name='lobbycal2press_settings[lobbycal2press_ical_filename]'
+	size="60"
+	value='<?php echo $ical_filename;  ?>'>
+<?php }
+
+function lobbycal2press_ical_title_prefix_render() {
+	$options = get_option ( 'lobbycal2press_settings' );
+	if ($options['lobbycal2press_ical_title_prefix'] == NULL) {
+		$ical_title_prefix = 'GreensEP LobbyCal:';
+	} else {
+		$ical_title_prefix = $options['lobbycal2press_ical_title_prefix'];
+	}	
+	?>
+	<input type='text'
+	name='lobbycal2press_settings[lobbycal2press_ical_title_prefix]'
+	size="60"
+	value='<?php echo $ical_title_prefix;  ?>'>
+<?php }
+
+function lobbycal2press_ical_static_content_render() {
+	$options = get_option ( 'lobbycal2press_settings' );
+	if ($options['lobbycal2press_ical_static_content'] == NULL) {
+		$ical_static_content = '';
+	} else {
+		$ical_static_content = $options['lobbycal2press_ical_static_content'];
+	}	
+	?>
+	<input type='text'
+	name='lobbycal2press_settings[lobbycal2press_ical_static_content]'
+	size="60"
+	value='<?php echo $ical_static_content;  ?>'>
+<?php }
+
+function lobbycal2press_ical_static_url_render() {
+	$options = get_option ( 'lobbycal2press_settings' );
+	if ($options['lobbycal2press_ical_static_url'] == NULL) {
+		$ical_static_url = '';
+	} else {
+		$ical_static_url = $options['lobbycal2press_ical_static_url'];
+	}	
+	?>
+	<input type='text'
+	name='lobbycal2press_settings[lobbycal2press_ical_static_url]'
+	size="60"
+	value='<?php echo $ical_static_url;  ?>'>
+<?php }
+
+function lobbycal2press_ical_fixed_location_render() {
+	$options = get_option ( 'lobbycal2press_settings' );
+	if ($options['lobbycal2press_ical_fixed_location'] == NULL) {
+		$fixed_location = '';
+	} else {
+		$fixed_location = $options['lobbycal2press_ical_fixed_location'];
+	}	
+	?>
+	<input type='text'
+	name='lobbycal2press_settings[lobbycal2press_ical_fixed_location]'
+	size="60"
+	value='<?php echo $fixed_location;  ?>'>
+<?php }
+
+function lobbycal2press_ical_fixed_location_latitude_render() {
+	$options = get_option ( 'lobbycal2press_settings' );
+	if ($options['lobbycal2press_ical_fixed_location_latitude'] == NULL) {
+		$fixed_location_latitude = '';
+	} else {
+		$fixed_location_latitude = $options['lobbycal2press_ical_fixed_location_latitude'];
+	}	
+	?>
+	<input type='text'
+	name='lobbycal2press_settings[lobbycal2press_ical_fixed_location_latitude]'
+	size="60"
+	value='<?php echo $fixed_location_latitude;  ?>'>
+<?php }
+
+function lobbycal2press_ical_fixed_location_longitude_render() {
+	$options = get_option ( 'lobbycal2press_settings' );
+	if ($options['lobbycal2press_ical_fixed_location_longitude'] == NULL) {
+		$fixed_location_longitude = '';
+	} else {
+		$fixed_location_longitude = $options['lobbycal2press_ical_fixed_location_longitude'];
+	}	
+	?>
+	<input type='text'
+	name='lobbycal2press_settings[lobbycal2press_ical_fixed_location_longitude]'
+	size="60"
+	value='<?php echo $fixed_location_longitude;  ?>'>
+<?php }
+
 function lobbycal2press_text_field_apiURL_render() {
 	$options = get_option ( 'lobbycal2press_settings' );
 	?>
@@ -120,7 +254,8 @@ function lobbycal2press_textarea_field_example_render() {
 	$options = get_option ( 'lobbycal2press_settings' );
 	?><textarea id="textarea_example"
 	name="lobbycal2press_settings[lobbycal2press_textarea_field_example]"
-	rows="14" cols="50">&lt;table id=&quot;lobbycal&quot; aria-describedby=&quot;lobbycal_info&quot;&gt;
+	rows="14" cols="50">&lt;p&gt;&lta href="<?php echo plugin_dir_url(__FILE__) . 'ical.php' ;?>" target="_blank"&gt;Subscribe to LobbyCal via iCal&lt;/a&gt; (copy link and use it within Thunderbird, Outlook, Google Calendar etc. to automatically receive infos about new meetings in your calendar - &lt;a href="https://www.webtermine.at/abo/abo-ical/" target="_blank"&gt;tutorials in German&lt;/a&gt;)&lt;/p&gt;
+&lt;table id=&quot;lobbycal&quot; aria-describedby=&quot;lobbycal_info&quot;&gt;
 	&lt;thead&gt;
 		&lt;tr&gt;
 			&lt;th&gt;Date&lt;/th&gt;
@@ -130,7 +265,7 @@ function lobbycal2press_textarea_field_example_render() {
 			&lt;th&gt;Partners&lt;/th&gt;
 			&lt;th&gt;Title&lt;/th&gt;
 			&lt;th&gt;Tags&lt;/th&gt;
-		&lt;/tr&gt; 
+		&lt;/tr&gt;
 	&lt;/thead&gt;
 &lt;/table&gt; 	
 </textarea>
@@ -234,78 +369,11 @@ function lobbycal2press_checkbox_field_tagsTitle_render() {
 	value='1'>
 <?php
 }
-function lobbycal2press_radio_field_order_render() {
-	$options = get_option ( 'lobbycal2press_settings' );
-	?>
-<input type='radio'
-	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
-	<?php checked( $options['lobbycal2press_radio_field_order'], 'startDate asc'); ?>
-	value='startDate asc'>
-Start date ascending
-</input>
-<br />
-<input type='radio'
-	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
-	<?php checked( $options['lobbycal2press_radio_field_order'],  'startDate desc'); ?>
-	value='startDate desc'>
-Start date descending
-</input>
-<br />
-<input type='radio'
-	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
-	<?php checked( $options['lobbycal2press_radio_field_order'], 'endDate asc'); ?>
-	value='endDate asc'>
-End date ascending
-</input>
-<br />
-<input type='radio'
-	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
-	<?php checked( $options['lobbycal2press_radio_field_order'],  'endDate desc'); ?>
-	value='endDate desc'>
-End date descending
-</input>
-<br />
-
-
-
-<input type='radio'
-	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
-	<?php checked( $options['lobbycal2press_radio_field_order'], 'userLastName asc'); ?>
-	value='userLastName asc'>
-Last name ascending
-</input>
-<br />
-<input type='radio'
-	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
-	<?php checked( $options['lobbycal2press_radio_field_order'],  'userLastName desc'); ?>
-	value='userLastName desc'>
-Last name descending
-</input>
-<br />
-
-
-
-
-<input type='radio'
-	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
-	<?php checked( $options['lobbycal2press_radio_field_order'], 'partners asc'); ?>
-	value='partners asc'>
-Partner ascending
-</input>
-<br />
-<input type='radio'
-	name='lobbycal2press_settings[lobbycal2press_radio_field_order]'
-	<?php checked( $options['lobbycal2press_radio_field_order'],  'partners desc'); ?>
-	value='partners desc'>
-Partner descending
-</input>
-<br />
-
-
-<?php
-}
 function lobbycal2press_settings_section_callback() {
 	echo __ ( 'The URL and at least one field are mandatory for the plugin to work. <br/> Make sure to use the https protocol here if your websites are accessed via https themselves.<br/> The default sorting of meetings is latest first.', 'lobbycal2press' );
+}
+function lobbycal2press_settings_section_ical_callback() {
+	echo __ ( 'Each calendar also automatically generates an iCal feed which can be used to automatically integrate the meetings into calendar programs like Outlook or Google Calendar for example. Some supported iCal metadata information is not available (yet?) from the API - anyway those info can be set globally below for all events. For tutorials on how to integrate an iCal feed with popular calendar clients, please have a look at <a href="https://www.webtermine.at/abo/abo-ical/" target="_blank">https://www.webtermine.at/abo/abo-ical/</a> (German)', 'lobbycal2press' );
 }
 function lobbycal2press_options_page() {
 	?>

--- a/src/lobbycal2press.php
+++ b/src/lobbycal2press.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: lobbycal2press for wordpress
  * Plugin URI: http://lobbycal.transparency.eu
- * Description: Plugin to display meetings from lobbycal.greens-efa-service.eu. Based on http://datatables.net/dev/knockout/
+ * Description: Plugin to display meetings from lobbycal.transparency.eu. Based on http://datatables.net/dev/knockout/
  * Version: 1.1
  * Author: GREENS EFA EU
  * Author URI: http://lobbycal.transparency.eu
@@ -60,7 +60,8 @@ function lobbycal2press_scripts() {
 	        var lc2pShowTags  = '<?php echo $options['lobbycal2press_checkbox_field_tags']; ?>';
 
 	        var lc2pShowTagsTitle  = '<?php echo $options['lobbycal2press_checkbox_field_tagsTitle']; ?>';
-			var lc2pOrder = '<?php echo $options['lobbycal2press_radio_field_order']; ?>';
+	        
+	        var lc2pOrder = '<?php echo $options['lobbycal2press_radio_field_order']; ?>';
 	        lc2pOrder = (lc2pOrder === undefined) ? 'date asc' : lc2pOrder;
 	        lc2pOrder = (lc2pOrder === '') ? 'date asc' : lc2pOrder;
 	        var lc2pPerPage  = '<?php echo $options['lobbycal2press_text_field_perPage']; ?>';


### PR DESCRIPTION
Example link for Michel Reimon´s meetings: https://www.reimon.net/wp-content/plugins/lobbycal2press/ical.php

Example link for all meetings: https://www.reimon.net/wp-content/plugins/lobbycal2press/ical.php?full

Some ical metadata info is not provided by the API (yet?), so you can set those settings by additional settings fields in the backend (prefixes, static texts, location, lat/lon values...):
![settings-example](https://cloud.githubusercontent.com/assets/158669/11540287/38966f24-992c-11e5-9b83-bafcbfe19e43.png)

I think that there is still an issue when trying to display all (past+future meetings): the API endpoint at https://lobbycal.greens-efa-service.eu/api/meetings/ only displays the latest 20 meetings - I would suggest removing the limitation so that if that endpoint is used, all past and future meetings are displayed.

regarding tutorials: we once created some German tutorials for users on how to use iCal within their favorite calendar app - I linked those tutorials (https://www.webtermine.at/abo/abo-ical/) - it would also help if those could be updated and made available via lobbycal.transparency.eu for example.
